### PR TITLE
Allow simulated time to decouple from real time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "flighty"
 version = "0.1.0"
-authors = ["tstellanova <tstellanova@users.noreply.github.com>"]
+authors = ["Todd Stellanova <tstellanova@users.noreply.github.com>"]
+license = "BSD-3-Clause"
+repository = "https://github.com/tstellanova/flighty"
+description = "Simple physical flight simulator"
 edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 nalgebra = "0.17.2"
-#sensulator = "0.4"
+sensulator = "0.4.2"
 
 [dev-dependencies]
 criterion = "0.2"
@@ -18,9 +18,9 @@ rand = "0.6.5"
 quickcheck = "0.6"
 
 
-[dependencies.sensulator]
+#[dependencies.sensulator]
 #path = "../sensulator"
-git = "https://github.com/tstellanova/sensulator.git"
+#git = "https://github.com/tstellanova/sensulator.git"
 
 [dependencies.num]
 version = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 nalgebra = "0.17.2"
-sensulator = "0.4"
+#sensulator = "0.4"
 
 [dev-dependencies]
 criterion = "0.2"
@@ -17,6 +17,10 @@ assert_approx_eq = "1.1.0"
 rand = "0.6.5"
 quickcheck = "0.6"
 
+
+[dependencies.sensulator]
+#path = "../sensulator"
+git = "https://github.com/tstellanova/sensulator.git"
 
 [dependencies.num]
 version = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ nalgebra = "0.17.2"
 sensulator = "0.4"
 
 [dev-dependencies]
+criterion = "0.2"
 assert_approx_eq = "1.1.0"
 rand = "0.6.5"
 quickcheck = "0.6"
@@ -18,3 +19,7 @@ quickcheck = "0.6"
 version = "0.2"
 default-features = false
 
+
+[[bench]]
+name = "time_loop_bench"
+harness = false

--- a/benches/time_loop_bench.rs
+++ b/benches/time_loop_bench.rs
@@ -1,0 +1,50 @@
+#[macro_use]
+extern crate criterion;
+
+use criterion::Criterion;
+
+extern crate flighty;
+use flighty::simulato::*;
+use flighty::physical_types::*;
+use flighty::models::ActuatorControls;
+use rand::prelude::*;
+
+
+
+fn get_test_reference_position() -> GlobalPosition {
+    GlobalPosition {
+        lat: 37.8716, //degrees
+        lon: -122.2727, //degrees
+        alt_wgs84: 10.0 //meters
+    }
+}
+
+
+/// Run the core simulation loop:
+/// - update the simulated time
+/// - change the actuator settings
+/// - repeat
+fn core_simulation() {
+    let mut simulato = Simulato::new(&get_test_reference_position());
+    simulato.increment_simulated_time();
+    let mut rng = rand::thread_rng();
+
+    for _i in 1..100 {
+        let rand_act_level = rng.gen::<f32>().abs();
+        let actuators: ActuatorControls = [rand_act_level; 16];
+        simulato.increment_simulated_time();
+        simulato.update(&actuators);
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("coresim", |b| b.iter(|| core_simulation()));
+}
+
+
+
+
+
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/time_loop_bench.rs
+++ b/benches/time_loop_bench.rs
@@ -42,9 +42,6 @@ fn criterion_benchmark(c: &mut Criterion) {
 }
 
 
-
-
-
-
 criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);
+

--- a/benches/time_loop_bench.rs
+++ b/benches/time_loop_bench.rs
@@ -9,6 +9,7 @@ use flighty::physical_types::*;
 use flighty::models::ActuatorControls;
 use rand::prelude::*;
 
+use assert_approx_eq::assert_approx_eq;
 
 
 fn get_test_reference_position() -> GlobalPosition {
@@ -35,6 +36,7 @@ fn core_simulation() {
         simulato.increment_simulated_time();
         simulato.update(&actuators);
     }
+    assert_approx_eq!(simulato.realtime_multiplier, 50.0, 5.0);
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/src/simulato.rs
+++ b/src/simulato.rs
@@ -75,7 +75,13 @@ impl Simulato {
         let delta_real_micros = real_micros - self.last_real_micros;
         self.last_real_micros = real_micros;
 
-        let simulated_delta_micros = Self::SIMULATED_TIME_MULTIPLIER * delta_real_micros;
+        //although we'd like to accelerate simulation infinitely, we need to ensure
+        //that the discrete simulation times are granular enough to represent
+        //an accurate simulation
+        let ideal_delta_micros = Self::SIMULATED_TIME_MULTIPLIER * delta_real_micros;
+        let simulated_delta_micros =
+            if ideal_delta_micros < 1000 { ideal_delta_micros } else { 1000};
+
         //println!("delta real: {} sim: {}", delta_real_micros, simulated_delta_micros);
         let new_sim_time = self.simulated_time + simulated_delta_micros;
 


### PR DESCRIPTION

The simulated time is now based on a multiplier of the real elapsed time, ideally 60x, but typically limited to less than that (25x - 50x in current tests) of the tradeoff between simulation speed and accuracy.  For accuracy we want the maximum simulated loop iteration time to be significantly less than the fastest simulated sensor -- currently those report at a simulated 400 Hz